### PR TITLE
Simplify call to GET /Players/ to reduce DDB hits

### DIFF
--- a/src/Web/Controllers/PlayerController.cs
+++ b/src/Web/Controllers/PlayerController.cs
@@ -30,9 +30,10 @@ public class PlayerController : ControllerBase
     public async Task<IActionResult> Get()
     {
         var players = await this._playerService.GetPlayers();
-        foreach (var player in players)
+        var locks = await this._lockService.GetLocks();
+        foreach (var player in locks.SelectMany(aLock => players.Where(player => aLock.Id == player.Id)))
         {
-            await this.SetPlayersDeathStatus(player);
+            player.IsDead = true;
         }
         return Ok(players);
     }

--- a/test/Web.Test/Controllers/PlayerControllerTest.cs
+++ b/test/Web.Test/Controllers/PlayerControllerTest.cs
@@ -49,9 +49,11 @@ public class PlayerControllerTest
             new("ghi", "jkl")
         };
         A.CallTo(() => this._playerService.GetPlayers()).Returns(players);
-        A.CallTo(() => this._lockService.GetLock("abc")).Throws<ResourceNotFoundException>();
-        A.CallTo(() => this._lockService.GetLock("ghi")).Returns(new Lock());
-        
+        A.CallTo(() => this._lockService.GetLocks()).Returns(new List<Lock>()
+        {
+            new("ghi", true)
+        });
+
         var result = await this._controller.Get() as ObjectResult;
         var playersResult = result.Value as List<Player>;
         Assert.IsFalse(playersResult[0].IsDead);


### PR DESCRIPTION
A nice performance improvement I thought of on my run earlier. I'm not sure why I didn't do this originally; but instead of calling `GetLock(id)` on `LockService` and seeing if it exists or not; just run one scan to get all locks and then map it over to the player using their IDs.

This has made it go from 120ms down to 30ms locally.